### PR TITLE
fix : `code` key moved

### DIFF
--- a/lib/utils/create-apollo-error.js
+++ b/lib/utils/create-apollo-error.js
@@ -20,10 +20,9 @@ function createApolloError(graphQLError, mapItem) {
     message,
     locations,
     extensions: {
-      code,
       data: typeof data === "function" ? data(originalError) : data,
     },
-  });
+  }, code);
 }
 
 module.exports = createApolloError;


### PR DESCRIPTION
`code` key moved in the return because the `toApolloError` function in `apollo-server` receive 2 parameters (data and code)
this `pull request` solves this `issue` : https://github.com/the-vampiire/apollo-error-converter/issues/8#issue-459437641