### PR TITLE
tests: fix jest/coveralls syntax, unmock toApolloError

### DIFF
--- a/lib/utils/tests/create-apollo-error.util.test.js
+++ b/lib/utils/tests/create-apollo-error.util.test.js
@@ -1,10 +1,5 @@
-const { toApolloError } = require("apollo-server-core");
 const { defaultFallback } = require("../../core/constants");
 const createApolloError = require("../create-apollo-error");
-
-jest.mock("apollo-server-core", () => ({
-  toApolloError: jest.fn(arg => arg),
-}));
 
 const path = ["a", "path"];
 const locations = [{ line: 1, column: 1 }];
@@ -31,15 +26,14 @@ describe("createApolloError: converts the original error to an Apollo Error", ()
     result = createApolloError(graphQLError, mapItem);
   });
 
-  test("converts the error to an Apollo Error", () => {
-    expect(toApolloError).toHaveBeenCalled();
-  });
-
   test("converted error includes the GraphQL path and location", () => {
-    ["path", "location"].forEach(property => expect(result[property]).toBe(graphQLError[property]));
+    ["path", "location"].forEach(property =>
+      expect(result[property]).toBe(graphQLError[property]),
+    );
   });
 
-  test("converted error has a top level message property from the mapItem", () => expect(result.message).toBe(mapItem.message));
+  test("converted error has a top level message property from the mapItem", () =>
+    expect(result.message).toBe(mapItem.message));
 
   test("converted error includes extensions object, { code, data }, from the mapItem", () => {
     expect(result.extensions).toBeDefined();
@@ -47,9 +41,7 @@ describe("createApolloError: converts the original error to an Apollo Error", ()
     expect(result.extensions.code).toBe(mapItem.code);
   });
 
-  test(`mapItem.code is not provided: uses default fallback code [${
-    defaultFallback.code
-  }]`, () => {
+  test(`mapItem.code is not provided: uses default fallback code [${defaultFallback.code}]`, () => {
     const noCodeResult = createApolloError(graphQLError, {
       message: "no code",
     });

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "jest",
     "test:core": "jest */*.core.test*",
     "test:utils": "jest */*.util.test*",
-    "test:travis": "jest --no-cache --coverage --coverageReporters=text-lcov | coveralls"
+    "test:travis": "jest --no-cache --coverage && coveralls < coverage/lcov.info"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- jest/coveralls recently patched their suggested usage due to tests failing but being passed by how coveralls is used ([coveralls link](https://github.com/nickmerwin/node-coveralls/commit/5e976c5dd179a1d3798af119e14a7bf414e0bdf2))
- unmocked toApolloError to enforce correct usage